### PR TITLE
Changed the media formatting for smaller screens on about page

### DIFF
--- a/Client/src/components/AboutSection/AboutElements.js
+++ b/Client/src/components/AboutSection/AboutElements.js
@@ -10,6 +10,9 @@ export const AboutContainer = styled.div`
   position: relative;
   z-index: 1;
   background: #2a456e;
+  @media screen and (max-width: 768px) {
+    height: 180vh;
+  }
 `;
 export const AboutWrapper = styled.div`
   display: flex;


### PR DESCRIPTION
Changed media formatting on about page so that both the text box and image were still visible on smaller screens.